### PR TITLE
Changes top level schema def

### DIFF
--- a/flow-typed/twenty-questions.types.js
+++ b/flow-typed/twenty-questions.types.js
@@ -24,6 +24,7 @@ export type q20$RenderedNode = {
   name: string,
   path: string,
   valueManager: q20$ValueManager,
+  register: (path: string) => typeof undefined,
   label?: string,
   description?: string,
   properties?: q20$Node[],
@@ -34,11 +35,7 @@ export type q20$RenderedNode = {
   validates?: string[],
 };
 
-export type q20$RenderedObjectNode = q20$RenderedNode & {
-  register?: (path: string) => typeof undefined,
-}
-
-export type q20$Node = q20$RenderedObjectNode & { type: q20$NodeType };
+export type q20$Node = q20$RenderedNode & { type: q20$NodeType };
 
 export type q20$NodeType = "object" | "string" | "array" | "number" | "boolean";
 
@@ -54,8 +51,11 @@ export type q20$FormControllerProps = {
   title: string,
   validate: q20$ValidateHOCPassedProps,
   name: string,
+  properties: q20$Node[],
   description?: string,
   widgets?: q20$RenderedNode[],
+  widget?: string,
+  label?: string,
 };
 
 export type q20$FormControllerState = {

--- a/public/example.js
+++ b/public/example.js
@@ -6,29 +6,27 @@ const ExampleApp = props => {
   return <Form
     title="FORM"
     description="This is a form"
-    schema={{
-      properties: [
-        {
-          type: "object",
-          name: "form-name",
-          label: "A simple form",
-          properties: [
-            {
-              type: "string",
-              name: "a_string",
-              label: "A String",
-              validates: ["required"],
-            },
-            {
-              type: "string",
-              name: "b_string",
-              label: "B String",
-              validates: ["required"],
-            },
-          ],
-        },
-      ],
-    }}
+    properties={[
+      {
+        type: "object",
+        name: "form-name",
+        label: "A simple form",
+        properties: [
+          {
+            type: "string",
+            name: "a_string",
+            label: "A String",
+            validates: ["required"],
+          },
+          {
+            type: "string",
+            name: "b_string",
+            label: "B String",
+            validates: ["required"],
+          },
+        ],
+      },
+    ]}
   />
 };
 

--- a/src/components/formController.js
+++ b/src/components/formController.js
@@ -4,6 +4,7 @@ import FormNodeObject from "./nodes/types/object";
 import getWidgets from "../utils/getWidgets";
 import withValidation from "./validator";
 import ErrorHandler from "./errorHandler";
+import camelize from "../utils/camelize";
 
 /**
  * FormController
@@ -64,6 +65,7 @@ export class FormController extends Component<
   /**
    * registerField
    *   Adds a field's path to the registry, but only once.
+   *
    * @param {string} path the field's path
    */
   registerField(path: string) {
@@ -85,28 +87,22 @@ export class FormController extends Component<
    * @return {React$Element} FormBuilder
    */
   render() {
-    const { widgets } = this.props;
-    const { title, description, properties } = this.props.schema;
-    if (properties[0].type !== "object") {
-      throw new Error(
-        "The first property in a 20-questions form must be of type object. Set all further fields/data as properties of that object.",
-      );
-    }
+    const { widgets, widget, title, description, properties, label } = this.props;
     return (
       <form>
         <h2>{title}</h2>
         {description && <h3>{description}</h3>}
 
         <FormNodeObject
-          key={`top-object-${this.props.name}.${properties[0].name}`}
-          name={properties[0].name}
-          label={properties[0].label}
-          description={properties[0].description}
+          key={`top-object-${camelize(title)}`}
+          name={camelize(title)}
+          label={label ? label : undefined}
+          description={description}
           type={"object"}
-          path={`${this.props.name}.${properties[0].name}`}
-          properties={properties[0].properties}
+          path={`${camelize(title)}`}
+          properties={properties}
           widgets={getWidgets(widgets)}
-          widget={properties[0].widget ? properties[0].widget : undefined}
+          widget={widget ? widget : undefined}
           valueManager={{
             update: this.changeValue,
             values: this.state.values,

--- a/src/components/nodes/types/object.js
+++ b/src/components/nodes/types/object.js
@@ -2,7 +2,7 @@
 import React from "react";
 import FormNode from "../../formNode";
 
-export const FormNodeObject = (props: q20$RenderedObjectNode) => {
+export const FormNodeObject = (props: q20$RenderedNode) => {
   let nodeContent = null;
   if (props.properties) {
     nodeContent = props.properties.map((property: q20$Node) => {

--- a/test/components/__snapshots__/formController.spec.js.snap
+++ b/test/components/__snapshots__/formController.spec.js.snap
@@ -2,25 +2,32 @@
 
 exports[`renders correctly 1`] = `
 <form>
-  <h2 />
+  <h2>
+    test form title
+  </h2>
   <h3>
     this is a test form
   </h3>
   <div>
-    <div
-      className="q20_node__string"
-    >
+    <span>
+      this is a test form
+    </span>
+    <div>
       <div
-        className="q20_testString__errorHandler"
+        className="q20_node__string"
       >
-        <input
-          className="q20_nodeString__testString--input"
-          id="undefined.test name.testString"
-          onChange={[Function]}
-          placeholder={undefined}
-          type="text"
-          value=""
-        />
+        <div
+          className="q20_testString__errorHandler"
+        >
+          <input
+            className="q20_nodeString__testString--input"
+            id="testFormTitle.test name.testString"
+            onChange={[Function]}
+            placeholder={undefined}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/test/components/formController.spec.js
+++ b/test/components/formController.spec.js
@@ -10,21 +10,19 @@ Enzyme.configure({ adapter: new Adapter() });
 
 const setupProps = {
   title: "test form title",
-  schema: {
-    description: "this is a test form",
-    properties: [
-      {
-        name: "test name",
-        type: "object",
-        properties: [
-          {
-            type: "string",
-            name: "testString",
-          },
-        ],
-      },
-    ],
-  },
+  description: "this is a test form",
+  properties: [
+    {
+      name: "test name",
+      type: "object",
+      properties: [
+        {
+          type: "string",
+          name: "testString",
+        },
+      ],
+    },
+  ],
 }
 
 it("renders correctly", () => {


### PR DESCRIPTION
Removed the idea of a schema at all, and just had the top level
FormController take a prop called "properties" and treated it as though
it were an object. The props are then passed down to an object rendering
component so everything may proceed as normal.

The "name" field should be optional, though encouraged. here it will not
error, but it will use the title (camel cased) to be the name field if
one isn't provided.