### PR TITLE
Array fields first row delete

### DIFF
--- a/src/utils/reorderBasedOnPath.js
+++ b/src/utils/reorderBasedOnPath.js
@@ -20,7 +20,9 @@ export default function reorderBasedOnPath({
 
   const sortedNamedValues = sortSelectedValuesByIndex(changesAndState);
   // renumbered values into their own object
-  const newValuesMatchingPath = renumberValuesIntoNewState({ sortedNamedValues });
+  const newValuesMatchingPath = renumberValuesIntoNewState({
+    sortedNamedValues,
+  });
   // filter out any entries that match the path, as they are now obsolete data
   let newState = deleteEntriesThatMatchPathWithNumber(changesAndState);
 
@@ -38,8 +40,14 @@ export default function reorderBasedOnPath({
  * @param {object} state the state being filtered
  * @return {object} the filtered state
  */
-function deleteEntriesThatMatchPathWithNumber({ path, state }: {path: string, state: {}}) {
-  const matchPathRegexp = new RegExp( path + "\\." );
+function deleteEntriesThatMatchPathWithNumber({
+  path,
+  state,
+}: {
+  path: string,
+  state: {},
+}) {
+  const matchPathRegexp = new RegExp(path + "\\.");
   const outputBuffer = {};
 
   for (let value in state) {

--- a/src/utils/reorderBasedOnPath.js
+++ b/src/utils/reorderBasedOnPath.js
@@ -1,5 +1,4 @@
 // @flow
-
 /**
  * reorderBasedOnPath
  *   Given an object of paths and values, will reorder them to fill
@@ -17,69 +16,41 @@ export default function reorderBasedOnPath({
   path: string,
   state: {},
 }) {
-  const newState = { ...state };
-  const changesAndState = { path, newState };
+  const changesAndState = { path, state };
 
   const sortedNamedValues = sortSelectedValuesByIndex(changesAndState);
-  renumberValuesIntoNewState({ sortedNamedValues, newState });
-  if (!areConsecutive(Object.keys(sortedNamedValues))) {
-    removeObsoleteRowEntries({
-      sortedNamedValues,
-      path,
-      newState,
-    });
-  }
+  // renumbered values into their own object
+  const newValuesMatchingPath = renumberValuesIntoNewState({ sortedNamedValues });
+  // filter out any entries that match the path, as they are now obsolete data
+  let newState = deleteEntriesThatMatchPathWithNumber(changesAndState);
+
+  // combine filtered state with updated array value state
+  newState = Object.assign(newState, newValuesMatchingPath);
   return newState;
 }
 
 /**
- * removeObsoleteRowEntries
- *   After shifting everything down one index value, there will be a leftover
- *   row, a duplicate of the one before it in order.
- *   Looking for the last index in sorted named values, when a path matching
- *   that is found, it is removed.
- * @param {object} pathValuesAndState path, sorted values and newState
- */
-function removeObsoleteRowEntries({
-  path,
-  sortedNamedValues,
-  newState,
-}: {
-  path: string,
-  sortedNamedValues: {},
-  newState: {},
-}) {
-  const sortedIndexes = Object.keys(sortedNamedValues);
-  const obsoleteRowRegex = new RegExp(
-    "^" + path + "\\." + sortedIndexes[sortedIndexes.length - 1],
-  );
-  for (let valuePair in newState) {
-    if (obsoleteRowRegex.test(valuePair)) {
-      delete newState[valuePair];
-    }
-  }
-}
-
-/**
- * areConsecutive
- *   takes in an array of numbers as strings.
- *   Returns true/false based on whether the numbers in the array are consecutive.
+ * deleteEntriesThatMatchPath
+ *   Filters out any value entries that match the path with an index in the path string
  *
- * @param {array} listOfNumbers
- * @return {boolean} true/false based on whether the numbers are consecutive.
+ * @param {object} arguments
+ * @param {string} path the path to match for deletion
+ * @param {object} state the state being filtered
+ * @return {object} the filtered state
  */
-export function areConsecutive(listOfNumbers: Array<string>) {
-  if (listOfNumbers.length <= 1) return false;
-  let sortedListOfNumbers = listOfNumbers.map(n => parseInt(n)).sort();
-  for (let i = 1, l = sortedListOfNumbers.length; i < l; i++) {
-    let currentNumber = sortedListOfNumbers[i];
-    if (currentNumber - 1 == sortedListOfNumbers[i - 1]) {
-      continue;
-    } else {
-      return false;
+function deleteEntriesThatMatchPathWithNumber({ path, state }: {path: string, state: {}}) {
+  const matchPathRegexp = new RegExp( path + "\\." );
+  const outputBuffer = {};
+
+  for (let value in state) {
+    if (state.hasOwnProperty(value)) {
+      if (!matchPathRegexp.test(value)) {
+        outputBuffer[value] = state[value];
+      }
     }
   }
-  return true;
+
+  return outputBuffer;
 }
 
 /**
@@ -87,17 +58,16 @@ export function areConsecutive(listOfNumbers: Array<string>) {
  *   Iterates through the paths based on their old index and changes it
  *   to the number of times through the loop.
  *   Ensures 0, 1, 2... order no matter their original index.
- * @param {object} sortedListAndState Sorted Named Values by index, and
- *   the current state, soon to be the new state.
- */
+ * @param {object} sortedListAndState Sorted Named Values by index
+ * @return {object} an object containing the new paths and values
+ * */
 function renumberValuesIntoNewState({
   sortedNamedValues,
-  newState,
 }: {
   sortedNamedValues: {},
-  newState: {},
 }) {
   const sortedIndexes = Object.keys(sortedNamedValues);
+  const outputBuffer = {};
 
   for (let i = 0, l = sortedIndexes.length; i < l; i++) {
     let oldIndex = sortedIndexes[i];
@@ -111,10 +81,11 @@ function renumberValuesIntoNewState({
           new RegExp("\\." + oldIndex + "\\."),
           "." + i + ".",
         );
-        newState[newPath] = oldValue;
+        outputBuffer[newPath] = oldValue;
       }
     }
   }
+  return outputBuffer;
 }
 
 /**
@@ -128,15 +99,15 @@ function renumberValuesIntoNewState({
  */
 function sortSelectedValuesByIndex({
   path,
-  newState,
+  state,
 }: {
   path: string,
-  newState: {},
+  state: {},
 }) {
   const sortedNamedValues = {};
   const pathTestCapturingIndex = new RegExp("^" + path + "\\.(\\d)");
-  for (let thisPath: string in newState) {
-    if (newState.hasOwnProperty(thisPath)) {
+  for (let thisPath: string in state) {
+    if (state.hasOwnProperty(thisPath)) {
       let doesMatchWithCapturedIndex = pathTestCapturingIndex.exec(thisPath);
 
       if (doesMatchWithCapturedIndex) {
@@ -145,7 +116,7 @@ function sortSelectedValuesByIndex({
           sortedNamedValues[index] = [];
         }
         sortedNamedValues[index].push({
-          [thisPath]: newState[thisPath],
+          [thisPath]: state[thisPath],
         });
       }
     }

--- a/src/utils/reorderBasedOnPath.spec.js
+++ b/src/utils/reorderBasedOnPath.spec.js
@@ -76,26 +76,21 @@ describe("reorderBasedOnPath", () => {
     });
     expect(Object.keys(result).length).toBe(Object.keys(arrayValue).length);
   });
-});
 
-describe("areConsecutive", () => {
-  it("returns true when the array of numbers is consecutive", () => {
-    const numbers = [1, 2, 3, 4, 5];
-    expect(areConsecutive(numbers)).toBeTruthy();
-  });
-
-  it("returns false when the array of numbers is not consecutive", () => {
-    const numbers = [1, 2, 3, 9, 10];
-    expect(areConsecutive(numbers)).toBe(false);
-  });
-
-  it("returns true when consecutive but not starting at zero", () => {
-    const numbers = [21, 22, 23, 24];
-    expect(areConsecutive(numbers)).toBe(true);
-  });
-
-  it("returns false when there is only one value", () => {
-    const numbers = [1];
-    expect(areConsecutive(numbers)).toBe(false);
+  it("should remove a duplicate row if it exists after reorder", () => {
+    const arrayValue = {
+      "testFormTitle.testName.testArray": {},
+      "testFormTitle.testName.testArray.1.a": {},
+      "testFormTitle.testName.testArray.1.a.one": "AAA",
+      "testFormTitle.testName.testArray.1.a.two": "BBB",
+      "testFormTitle.testName.testArray.2.a": {},
+      "testFormTitle.testName.testArray.2.a.one": "AAAA",
+      "testFormTitle.testName.testArray.2.a.two": "BBBB",
+    };
+    const result = reorderBasedOnPath({
+      path: "testFormTitle.testName.testArray",
+      state: arrayValue,
+    });
+    expect(Object.keys(result).length).toBe(Object.keys(arrayValue).length);
   });
 });

--- a/src/utils/reorderBasedOnPath.spec.js
+++ b/src/utils/reorderBasedOnPath.spec.js
@@ -1,6 +1,4 @@
-import reorderBasedOnPath, {
-  areConsecutive,
-} from "../../src/utils/reorderBasedOnPath";
+import reorderBasedOnPath from "../../src/utils/reorderBasedOnPath";
 
 describe("reorderBasedOnPath", () => {
   const arrayValue = {


### PR DESCRIPTION
Found a better solution for the array renumbering problem. Instead of having to decide whether or not certain key/value pairs need to be deleted one way or another, the following is applied...

A new object is created from the incumbent state that filters away all the value pairs whose paths match the string in question.
Another new object is created that holds the reordered value pairs post-deletion.
These two objects are merged together.

This removes some complicated logic around which rows in the value object were being saved vs deleted.